### PR TITLE
work around the type alias problem with borrowed and shared/owned

### DIFF
--- a/src/LisExprData.chpl
+++ b/src/LisExprData.chpl
@@ -12,6 +12,22 @@ module LisExprData
     /* in a real scheme/lisp interpreter these two enums (LVT and VT) would be the same */
     enum VT {I, R};
 
+    /* type: generic list values */
+    type GenListValue = shared GenListValueClass;
+    type BGenListValue = borrowed GenListValueClass;
+    type ListValue = shared ListValueClass;
+    type BListValue = borrowed ListValueClass;
+    
+    /* type: list of generic list values */
+    type GenList = shared ListClass(GenListValue);
+    type BGenlist = borrowed ListClass(GenListValue);
+    
+    /* type: generic values for eval */
+    type GenValue = owned GenValueClass;
+    type BGenValue = borrowed GenValueClass;
+    type Value = owned ValueClass;
+    type BValue = borrowed ValueClass;
+
     /*
       List Class wraps the standard List which is a record
       forwarding the interface to the class definition
@@ -22,11 +38,8 @@ module LisExprData
       forwarding var l: list(etype);
     }
     
-    /* type: list of genric list values */
-    type GenList = shared ListClass(owned GenListValue);
-
-    /* generic list value */
-    class GenListValue
+    /* generic list value class def */
+    class GenListValueClass
     {
         var lvt: LVT;
         
@@ -40,31 +53,31 @@ module LisExprData
         
         /* cast to the GenListValue to borrowed ListValue(vtype) halt on failure */
         inline proc toListValue(type lvtype) {
-            return try! this :borrowed ListValue(lvtype);
+            return try! this :BListValue(lvtype);
         }
 
         /* returns a copy of this... an owned GenListValue */
-        proc copy(): owned GenListValue throws {
+        proc copy(): GenListValue throws {
           select (this.lvt) {
             when (LVT.Lst) {
-              return new owned ListValue(this.toListValue(GenList).lv);
+              return new ListValue(this.toListValue(GenList).lv);
             }
             when (LVT.Sym) {
-              return new owned ListValue(this.toListValue(Symbol).lv);
+              return new ListValue(this.toListValue(Symbol).lv);
             }
             when (LVT.I) {
-              return new owned ListValue(this.toListValue(int).lv);
+              return new ListValue(this.toListValue(int).lv);
             }
             when (LVT.R) {
-              return new owned ListValue(this.toListValue(real).lv);
+              return new ListValue(this.toListValue(real).lv);
             }
             otherwise {throw new owned Error("not implemented");}
           }
         }
     }
     
-    /* concrete list value */
-    class ListValue : GenListValue
+    /* concrete list value class def */
+    class ListValueClass : GenListValueClass
     {
         type lvtype;
         var lv: lvtype;
@@ -79,9 +92,9 @@ module LisExprData
         
     }
 
-
+    
     /* generic value class */
-    class GenValue
+    class GenValueClass
     {
         /* value type testable at runtime */
         var vt: VT;
@@ -94,21 +107,21 @@ module LisExprData
         
         /* cast to the GenValue to borrowed Value(vtype) halt on failure */
         inline proc toValue(type vtype) {
-            return try! this :borrowed Value(vtype);
+            return try! this :BValue(vtype);
         }
 
         /* returns a copy of this... an owned GenValue */
-        proc copy(): owned GenValue throws {
+        proc copy(): GenValue throws {
             select (this.vt) {
-                when (VT.I) {return new owned Value(this.toValue(int).v);}
-                when (VT.R) {return new owned Value(this.toValue(real).v);}
+                when (VT.I) {return new Value(this.toValue(int).v);}
+                when (VT.R) {return new Value(this.toValue(real).v);}
                 otherwise { throw new owned Error("not implemented"); }
             }
         }
     }
     
     /* concrete value class */
-    class Value : GenValue
+    class ValueClass : GenValueClass
     {
         type vtype; // value type
         var v: vtype; // value
@@ -125,109 +138,109 @@ module LisExprData
     // operators over GenValue
     //////////////////////////////////////////
     
-    inline operator +(l: borrowed GenValue, r: borrowed GenValue): owned GenValue throws {
+    inline operator +(l: BGenValue, r: BGenValue): GenValue throws {
         select (l.vt, r.vt) {
-            when (VT.I, VT.I) {return new owned Value(l.toValue(int).v + r.toValue(int).v);}
-            when (VT.I, VT.R) {return new owned Value(l.toValue(int).v + r.toValue(real).v);}
-            when (VT.R, VT.I) {return new owned Value(l.toValue(real).v + r.toValue(int).v);}
-            when (VT.R, VT.R) {return new owned Value(l.toValue(real).v + r.toValue(real).v);}
+            when (VT.I, VT.I) {return new Value(l.toValue(int).v + r.toValue(int).v);}
+            when (VT.I, VT.R) {return new Value(l.toValue(int).v + r.toValue(real).v);}
+            when (VT.R, VT.I) {return new Value(l.toValue(real).v + r.toValue(int).v);}
+            when (VT.R, VT.R) {return new Value(l.toValue(real).v + r.toValue(real).v);}
             otherwise {throw new owned Error("not implemented");}
         }
     }
 
-    inline operator -(l: borrowed GenValue, r: borrowed GenValue): owned GenValue throws {
+    inline operator -(l: BGenValue, r: BGenValue): GenValue throws {
         select (l.vt, r.vt) {
-            when (VT.I, VT.I) {return new owned Value(l.toValue(int).v - r.toValue(int).v);}
-            when (VT.I, VT.R) {return new owned Value(l.toValue(int).v - r.toValue(real).v);}
-            when (VT.R, VT.I) {return new owned Value(l.toValue(real).v - r.toValue(int).v);}
-            when (VT.R, VT.R) {return new owned Value(l.toValue(real).v - r.toValue(real).v);}
+            when (VT.I, VT.I) {return new Value(l.toValue(int).v - r.toValue(int).v);}
+            when (VT.I, VT.R) {return new Value(l.toValue(int).v - r.toValue(real).v);}
+            when (VT.R, VT.I) {return new Value(l.toValue(real).v - r.toValue(int).v);}
+            when (VT.R, VT.R) {return new Value(l.toValue(real).v - r.toValue(real).v);}
             otherwise {throw new owned Error("not implemented");}
         }
     }
 
-    inline operator *(l: borrowed GenValue, r: borrowed GenValue): owned GenValue throws {
+    inline operator *(l: BGenValue, r: BGenValue): GenValue throws {
         select (l.vt, r.vt) {
-            when (VT.I, VT.I) {return new owned Value(l.toValue(int).v * r.toValue(int).v);}
-            when (VT.I, VT.R) {return new owned Value(l.toValue(int).v * r.toValue(real).v);}
-            when (VT.R, VT.I) {return new owned Value(l.toValue(real).v * r.toValue(int).v);}
-            when (VT.R, VT.R) {return new owned Value(l.toValue(real).v * r.toValue(real).v);}
+            when (VT.I, VT.I) {return new Value(l.toValue(int).v * r.toValue(int).v);}
+            when (VT.I, VT.R) {return new Value(l.toValue(int).v * r.toValue(real).v);}
+            when (VT.R, VT.I) {return new Value(l.toValue(real).v * r.toValue(int).v);}
+            when (VT.R, VT.R) {return new Value(l.toValue(real).v * r.toValue(real).v);}
             otherwise {throw new owned Error("not implemented");}
         }
     }
 
-    inline operator <(l: borrowed GenValue, r: borrowed GenValue): owned GenValue throws {
+    inline operator <(l: BGenValue, r: BGenValue): GenValue throws {
         select (l.vt, r.vt) {
-            when (VT.I, VT.I) {return new owned Value((l.toValue(int).v < r.toValue(int).v):int);}
-            when (VT.I, VT.R) {return new owned Value((l.toValue(int).v < r.toValue(real).v):int);}
-            when (VT.R, VT.I) {return new owned Value((l.toValue(real).v < r.toValue(int).v):int);}
-            when (VT.R, VT.R) {return new owned Value((l.toValue(real).v < r.toValue(real).v):int);}
+            when (VT.I, VT.I) {return new Value((l.toValue(int).v < r.toValue(int).v):int);}
+            when (VT.I, VT.R) {return new Value((l.toValue(int).v < r.toValue(real).v):int);}
+            when (VT.R, VT.I) {return new Value((l.toValue(real).v < r.toValue(int).v):int);}
+            when (VT.R, VT.R) {return new Value((l.toValue(real).v < r.toValue(real).v):int);}
             otherwise {throw new owned Error("not implemented");}
         }
     }
 
-    inline operator >(l: borrowed GenValue, r: borrowed GenValue): owned GenValue throws {
+    inline operator >(l: BGenValue, r: BGenValue): GenValue throws {
         select (l.vt, r.vt) {
-            when (VT.I, VT.I) {return new owned Value((l.toValue(int).v > r.toValue(int).v):int);}
-            when (VT.I, VT.R) {return new owned Value((l.toValue(int).v > r.toValue(real).v):int);}
-            when (VT.R, VT.I) {return new owned Value((l.toValue(real).v > r.toValue(int).v):int);}
-            when (VT.R, VT.R) {return new owned Value((l.toValue(real).v > r.toValue(real).v):int);}
+            when (VT.I, VT.I) {return new Value((l.toValue(int).v > r.toValue(int).v):int);}
+            when (VT.I, VT.R) {return new Value((l.toValue(int).v > r.toValue(real).v):int);}
+            when (VT.R, VT.I) {return new Value((l.toValue(real).v > r.toValue(int).v):int);}
+            when (VT.R, VT.R) {return new Value((l.toValue(real).v > r.toValue(real).v):int);}
             otherwise {throw new owned Error("not implemented");}
         }
     }
 
-    inline operator <=(l: borrowed GenValue, r: borrowed GenValue): owned GenValue throws {
+    inline operator <=(l: BGenValue, r: BGenValue): GenValue throws {
         select (l.vt, r.vt) {
-            when (VT.I, VT.I) {return new owned Value((l.toValue(int).v <= r.toValue(int).v):int);}
-            when (VT.I, VT.R) {return new owned Value((l.toValue(int).v <= r.toValue(real).v):int);}
-            when (VT.R, VT.I) {return new owned Value((l.toValue(real).v <= r.toValue(int).v):int);}
-            when (VT.R, VT.R) {return new owned Value((l.toValue(real).v <= r.toValue(real).v):int);}
+            when (VT.I, VT.I) {return new Value((l.toValue(int).v <= r.toValue(int).v):int);}
+            when (VT.I, VT.R) {return new Value((l.toValue(int).v <= r.toValue(real).v):int);}
+            when (VT.R, VT.I) {return new Value((l.toValue(real).v <= r.toValue(int).v):int);}
+            when (VT.R, VT.R) {return new Value((l.toValue(real).v <= r.toValue(real).v):int);}
             otherwise {throw new owned Error("not implemented");}
         }
     }
 
-    inline operator >=(l: borrowed GenValue, r: borrowed GenValue): owned GenValue throws {
+    inline operator >=(l: BGenValue, r: BGenValue): GenValue throws {
         select (l.vt, r.vt) {
-            when (VT.I, VT.I) {return new owned Value((l.toValue(int).v >= r.toValue(int).v):int);}
-            when (VT.I, VT.R) {return new owned Value((l.toValue(int).v >= r.toValue(real).v):int);}
-            when (VT.R, VT.I) {return new owned Value((l.toValue(real).v >= r.toValue(int).v):int);}
-            when (VT.R, VT.R) {return new owned Value((l.toValue(real).v >= r.toValue(real).v):int);}
+            when (VT.I, VT.I) {return new Value((l.toValue(int).v >= r.toValue(int).v):int);}
+            when (VT.I, VT.R) {return new Value((l.toValue(int).v >= r.toValue(real).v):int);}
+            when (VT.R, VT.I) {return new Value((l.toValue(real).v >= r.toValue(int).v):int);}
+            when (VT.R, VT.R) {return new Value((l.toValue(real).v >= r.toValue(real).v):int);}
             otherwise {throw new owned Error("not implemented");}
         }
     }
 
-    inline operator ==(l: borrowed GenValue, r: borrowed GenValue): owned GenValue throws {
+    inline operator ==(l: BGenValue, r: BGenValue): GenValue throws {
         select (l.vt, r.vt) {
-            when (VT.I, VT.I) {return new owned Value((l.toValue(int).v == r.toValue(int).v):int);}
-            when (VT.I, VT.R) {return new owned Value((l.toValue(int).v == r.toValue(real).v):int);}
-            when (VT.R, VT.I) {return new owned Value((l.toValue(real).v == r.toValue(int).v):int);}
-            when (VT.R, VT.R) {return new owned Value((l.toValue(real).v == r.toValue(real).v):int);}
+            when (VT.I, VT.I) {return new Value((l.toValue(int).v == r.toValue(int).v):int);}
+            when (VT.I, VT.R) {return new Value((l.toValue(int).v == r.toValue(real).v):int);}
+            when (VT.R, VT.I) {return new Value((l.toValue(real).v == r.toValue(int).v):int);}
+            when (VT.R, VT.R) {return new Value((l.toValue(real).v == r.toValue(real).v):int);}
             otherwise {throw new owned Error("not implemented");}
         }
     }
 
-    inline operator !=(l: borrowed GenValue, r: borrowed GenValue): owned GenValue throws {
+    inline operator !=(l: BGenValue, r: BGenValue): GenValue throws {
         select (l.vt, r.vt) {
-            when (VT.I, VT.I) {return new owned Value((l.toValue(int).v != r.toValue(int).v):int);}
-            when (VT.I, VT.R) {return new owned Value((l.toValue(int).v != r.toValue(real).v):int);}
-            when (VT.R, VT.I) {return new owned Value((l.toValue(real).v != r.toValue(int).v):int);}
-            when (VT.R, VT.R) {return new owned Value((l.toValue(real).v != r.toValue(real).v):int);}
+            when (VT.I, VT.I) {return new Value((l.toValue(int).v != r.toValue(int).v):int);}
+            when (VT.I, VT.R) {return new Value((l.toValue(int).v != r.toValue(real).v):int);}
+            when (VT.R, VT.I) {return new Value((l.toValue(real).v != r.toValue(int).v):int);}
+            when (VT.R, VT.R) {return new Value((l.toValue(real).v != r.toValue(real).v):int);}
             otherwise {throw new owned Error("not implemented");}
         }
     }
 
-    inline proc and(l: borrowed GenValue, r: borrowed GenValue): owned GenValue throws {
-        return new owned Value((l && r):int);
+    inline proc and(l: BGenValue, r: BGenValue): GenValue throws {
+        return new Value((l && r):int);
     }
 
-    inline proc or(l: borrowed GenValue, r: borrowed GenValue): owned GenValue throws {
-        return new owned Value((l || r):int);
+    inline proc or(l: BGenValue, r: BGenValue): GenValue throws {
+        return new Value((l || r):int);
     }
 
-    inline proc not(l: borrowed GenValue): owned GenValue throws {
-        return new owned Value((! isTrue(l)):int);
+    inline proc not(l: BGenValue): GenValue throws {
+        return new Value((! isTrue(l)):int);
     }
 
-    inline proc isTrue(gv: borrowed GenValue): bool throws {
+    inline proc isTrue(gv: BGenValue): bool throws {
         select (gv.vt) {
             when (VT.I) {return (gv.toValue(int).v != 0);}
             when (VT.R) {return (gv.toValue(real).v != 0.0);}
@@ -240,11 +253,11 @@ module LisExprData
     {
         /* what data structure to use ??? assoc array over strings or a map ? */
         var tD: domain(string);
-        var tab: [tD] owned GenValue?;
+        var tab: [tD] GenValue?;
 
         /* add a new entry or set an entry to a new value */
-        proc addEntry(name:string, val: ?t): borrowed Value(t) throws {
-            var entry = new owned Value(val);
+        proc addEntry(name:string, val: ?t): BValue(t) throws {
+            var entry = new Value(val);
             if (!tD.contains(name)) {tD += name;};
             ref tableEntry = tab[name];
             tableEntry = entry;
@@ -252,7 +265,7 @@ module LisExprData
         }
 
         /* add a new entry or set an entry to a new value */
-        proc addEntry(name:string, in entry: owned GenValue): borrowed GenValue throws {
+        proc addEntry(name:string, in entry: GenValue): BGenValue throws {
             if (!tD.contains(name)) {tD += name;};
             ref tableEntry = tab[name];
             tableEntry = entry;
@@ -260,7 +273,7 @@ module LisExprData
         }
 
         /* lookup symbol and throw error if not found */
-        proc lookup(name: string): borrowed GenValue throws {
+        proc lookup(name: string): BGenValue throws {
             if (!tD.contains(name) || tab[name] == nil) {
               throw new owned Error("undefined symbol error " + name);
             }

--- a/src/LisExprInterp.chpl
+++ b/src/LisExprInterp.chpl
@@ -14,7 +14,7 @@ module LisExprInterp
     /*
       parse, check, and validate code and all symbols in the tokenized prog
     */ 
-    proc parse(line: string): owned GenListValue throws {
+    proc parse(line: string): GenListValue throws {
         // Want:
         //   return read_from_tokens(tokenize(line));
         //
@@ -28,7 +28,7 @@ module LisExprInterp
       parse throught the list of tokens generating the parse tree / AST
       as a list of atoms and lists
     */
-    proc read_from_tokens(ref tokens: list(string)): owned GenListValue throws {
+    proc read_from_tokens(ref tokens: list(string)): GenListValue throws {
         if (tokens.size == 0) then
             throw new owned Error("SyntaxError: unexpected EOF");
 
@@ -45,7 +45,7 @@ module LisExprInterp
                     throw new owned Error("SyntaxError: unexpected EOF");
             }
             tokens.pop(0); // pop off ")"
-            return new owned ListValue(L);
+            return new ListValue(L);
         }
         else if (token == ")") {
             throw new owned Error("SyntaxError: unexpected )");
@@ -56,20 +56,20 @@ module LisExprInterp
     }
     
     /* determine atom type and values */
-    proc atom(token: string): owned GenListValue {
+    proc atom(token: string): GenListValue {
         try { // try to interpret as an integer ?
-            return new owned ListValue(token:int); 
+            return new ListValue(token:int); 
         } catch {
             try { //try to interpret it as a real ?
-                return new owned ListValue(token:real);
+                return new ListValue(token:real);
             } catch { // return it as a symbol
-                return new owned ListValue(token);
+                return new ListValue(token);
             }
         }
     }
     
     /* check to see if list value is a symbol otherwise throw error */
-    inline proc checkSymbol(arg: borrowed GenListValue) throws {
+    inline proc checkSymbol(arg: BGenListValue) throws {
         if (arg.lvt != LVT.Sym) {
           throw new owned Error("arg must be a symbol " + arg:string);
         }
@@ -92,7 +92,7 @@ module LisExprInterp
     /*
       evaluate the expression
     */
-    proc eval(ast: borrowed GenListValue, env: borrowed Env): owned GenValue throws {
+    proc eval(ast: BGenListValue, env: borrowed Env): GenValue throws {
         select (ast.lvt) {
             when (LVT.Sym) {
                 var gv = env.lookup(ast.toListValue(Symbol).lv);
@@ -100,11 +100,11 @@ module LisExprInterp
             }
             when (LVT.I) {
                 var ret: int = ast.toListValue(int).lv;
-                return new owned Value(ret);
+                return new Value(ret);
             }
             when (LVT.R) {
                 var ret: real = ast.toListValue(real).lv;
-                return new owned Value(ret);
+                return new Value(ret);
             }
             when (LVT.Lst) {
                 ref lst = ast.toListValue(GenList).lv;


### PR DESCRIPTION
changes here are related to my desire to be able to change between `owned` and `shared` in type definition so I don't have to change all the places in the code where the type is used.

there is a Chapel issue about this:
https://github.com/chapel-lang/chapel/issues/20082